### PR TITLE
Make residue numbering cyclical.

### DIFF
--- a/src/setup_gmx.py
+++ b/src/setup_gmx.py
@@ -369,7 +369,7 @@ def write_psf(topdat, sysdat):
                 for kdx in range(topdat[idx].nat):
                     atidx += 1
                     print("{:8} {:<4}{:5} {:<4} {:<4} {:<4}  {:9.6f}  {:12.4f}".format(
-                           atidx, topdat[idx].resname[kdx], min(9999,molidx), 
+                           atidx, topdat[idx].resname[kdx], molidx % 10000, 
                            topdat[idx].resname[kdx], topdat[idx].atomname[kdx], topdat[idx].atomtype[kdx], 
                            topdat[idx].charge[kdx], topdat[idx].mass[kdx]), file=fout)
         print(file=fout)

--- a/src/setup_lmp.py
+++ b/src/setup_lmp.py
@@ -289,7 +289,7 @@ def write_psf(topdat, sysdat):
                     atidx += 1
                     tot_charge += topdat[idx].charge[kdx]
                     print("{:8} {:<4}{:5} {:<4} {:<4} {:<4}  {:9.6f}  {:12.4f}".format(
-                           atidx, topdat[idx].resname[kdx], min(9999,molidx), 
+                           atidx, topdat[idx].resname[kdx], molidx % 10000, 
                            topdat[idx].resname[kdx], topdat[idx].atomname[kdx],topdat[idx].atomtype[kdx], 
                            topdat[idx].charge[kdx], topdat[idx].mass[kdx]), file=fout)
         if abs(tot_charge) < 1e-6:


### PR DESCRIPTION
This PR fixes a long-time issue that causes residue numbering to stop at 9999 in PSF files.

While this has no effect on simulation accuracy, it proves problematic in analysis, namely when selecting by residue id.

The behaviour is changed instead to set the CG residue to its number modulo 10000.